### PR TITLE
re-verify token after changing enforce_ttl

### DIFF
--- a/lib/relish/encryption_helper.rb
+++ b/lib/relish/encryption_helper.rb
@@ -51,6 +51,7 @@ class Relish
     def verifier(secret, token)
       Fernet.verifier(secret, token).tap do |verifier|
         verifier.enforce_ttl = false
+        verifier.verify_token(token)
       end
     rescue OpenSSL::Cipher::CipherError
     end


### PR DESCRIPTION
Relish leans on `Fernet.verifier` which calls `verify_token` before returning.  `verify_token` is what sets the `valid` accessor.  Since TTLs don't line up, `false` is returned.

https://github.com/hgmnz/fernet/blob/9fa4009896e8e17151a534c880dd5cd01ef6bfaf/lib/fernet.rb#L22

This adjusts things so `verify_token` is called after you choose to ignore ttls, thus giving us a valid `Verifier`.
