### PR TITLE
add support for dynamodb local with more flexible connection options

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+end

--- a/test/relish_test.rb
+++ b/test/relish_test.rb
@@ -1,0 +1,28 @@
+require_relative "test_helper"
+
+describe Relish do
+    it "initializes legacy style" do
+      r = Relish.new('accessKey', 'secretKey', 'tablename')
+      r.instance_variable_get("@db").db.must_be_instance_of Fog::AWS::DynamoDB::Real
+    end
+
+    it "initializes new style" do
+      r = Relish.new(
+        :aws_access_key_id => 'aws_access_key',
+        :aws_secret_access_key => 'aws_secret_key',
+        :table_name => 'tablename'
+      )
+      r.instance_variable_get("@db").db.must_be_instance_of Fog::AWS::DynamoDB::Real
+    end
+
+    it "initializes new style localhost" do
+      r = Relish.new(
+          :aws_access_key_id => 'aws_access_key',
+          :aws_secret_access_key => 'aws_secret_key',
+          :host => 'localhost',
+          :port => 8080,
+          :scheme => 'http'
+      )
+      r.instance_variable_get("@db").db.must_be_instance_of Fog::AWS::DynamoDB::Real
+    end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+require "minitest/autorun"
+require "minitest/spec"
+
+require_relative "../lib/relish"


### PR DESCRIPTION
@jkakar mark fine is gone, so I'm not sure who wants to +1 this for merge. This is needed to enable dynamodb local support. There were no tests so I added some to cover my changes.
