### PR TITLE
Bump fog/lock versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     relishable (0.29)
-      fog
-      legacy-fernet
+      fog (~> 1.23.0)
+      legacy-fernet (~> 1.6.3)
 
 GEM
   remote: http://rubygems.org/
@@ -13,31 +13,39 @@ GEM
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
-    excon (0.39.4)
-    fog (1.21.0)
+    excon (0.39.6)
+    fog (1.23.0)
       fog-brightbox
-      fog-core (~> 1.21, >= 1.21.1)
+      fog-core (~> 1.23)
       fog-json
+      fog-softlayer
+      ipaddress (~> 0.5)
       nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.0.1)
-      fog-core
+    fog-brightbox (0.5.1)
+      fog-core (~> 1.22)
       fog-json
-    fog-core (1.21.1)
+      inflecto
+    fog-core (1.24.0)
       builder
-      excon (~> 0.32)
-      formatador (~> 0.2.0)
+      excon (~> 0.38)
+      formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
     fog-json (1.0.0)
       multi_json (~> 1.0)
-    formatador (0.2.4)
+    fog-softlayer (0.3.19)
+      fog-core
+      fog-json
+    formatador (0.2.5)
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
     legacy-fernet (1.6.3)
       multi_json
     mime-types (2.3)
     mini_portile (0.6.0)
     multi_json (1.10.1)
-    net-scp (1.1.2)
+    net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
     nokogiri (1.6.3.1)

--- a/relishable.gemspec
+++ b/relishable.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
-  s.add_dependency "fog"
-  s.add_dependency "legacy-fernet"
+  s.add_dependency "fog",           "~> 1.23.0"
+  s.add_dependency "legacy-fernet", "~> 1.6.3"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rspec",   "~> 3.1.0"
   s.add_development_dependency "webmock", "~> 1.19.0"


### PR DESCRIPTION
Relishable is currently on Fog 1.21.0. This bump should be fairly safe, and fix the annoying deprecation warning we're seeing in tests.
