### PR TITLE
Updating Gemspec with opensource@heroku.com email

### DIFF
--- a/relishable.gemspec
+++ b/relishable.gemspec
@@ -3,11 +3,11 @@ require "relish/version"
 
 Gem::Specification.new do |s|
   s.name = "relishable"
-  s.email = "pedro@heroku.com"
+  s.email = ["pedro@heroku.com", "mark.fine@gmail.com", "tobin@heroku.com", "opensource@heroku.com"]
   s.version = Relish::VERSION
   s.description = "Release manager."
   s.summary = "releases"
-  s.authors = ["Pedro Belo"]
+  s.authors = ["Mark Fine", "Blake Gentry", "Pedro Belo", "Joshua Tobin"]
   s.homepage = "http://github.com/heroku/relish"
 
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]


### PR DESCRIPTION
Adding opensource@heroku.com to gemspec to register with rubygems. CC: @pedro 
