### PR TITLE
Specify format

### DIFF
--- a/lib/relish/release.rb
+++ b/lib/relish/release.rb
@@ -31,6 +31,7 @@ class Relish
            :addons               => :S,
            :uuid                 => :S,
            :app_uuid             => :S,
-           :app_name             => :S
+           :app_name             => :S,
+           :format               => :S
   end
 end


### PR DESCRIPTION
This adds a format attribute which we can use to version the release payload itself. The idea is to have Psmgr select a parser based on this value. Psmgr will then add support for a new format and we'll then start using this in the API.