### PR TITLE
Add slug checksum

### DIFF
--- a/lib/relish/release.rb
+++ b/lib/relish/release.rb
@@ -18,6 +18,7 @@ class Relish
            :route_id             => :S,
            :slug_uuid            => :S,
            :slug_id              => :S,
+           :slug_checksum        => :S,
            :slug_version         => :N,
            :stack                => :S,
            :language_pack        => :S,


### PR DESCRIPTION
This allows passing through a checksum that can be used for verifying the slug's integrity.