### PR TITLE
Draft releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,9 @@ PATH
   remote: .
   specs:
     relishable (0.35)
-      fog (~> 1.23.0)
+      fog-aws (~> 0.8.0)
       legacy-fernet (~> 1.6.3)
+      net-ssh (~> 3.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -14,38 +15,30 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     excon (0.45.4)
-    fog (1.23.0)
-      fog-brightbox
-      fog-core (~> 1.23)
-      fog-json
-      fog-softlayer
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-brightbox (0.9.0)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-core (1.33.0)
+    fog-aws (0.8.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.35.0)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
-      mime-types
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-softlayer (1.0.2)
+    fog-xml (0.1.2)
       fog-core
-      fog-json
+      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    inflecto (0.0.2)
-    ipaddress (0.8.0)
+    ipaddress (0.8.2)
     legacy-fernet (1.6.3)
       multi_json
-    mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     multi_json (1.11.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    net-ssh (3.0.2)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
     power_assert (0.2.2)
     rake (10.4.2)
     rspec (3.1.0)

--- a/lib/relish.rb
+++ b/lib/relish.rb
@@ -26,7 +26,7 @@ class Relish
 
   def create(id, data)
     rescue_dynamodb_error do
-      item = @db.query_current_version(id)
+      item = @db.query_latest_version(id)
       Release.new.tap do |release|
         if item.nil?
           release.item = {}
@@ -76,7 +76,7 @@ class Relish
       end
     end
   end
-    
+
   def update(id, version, data)
     rescue_dynamodb_error do
       item = @db.get_version(id, version)

--- a/lib/relish/release.rb
+++ b/lib/relish/release.rb
@@ -14,6 +14,7 @@ class Relish
            :version              => :N,
            :name                 => :S,
            :descr                => :S,
+           :draft                => :BOOL,
            :user_id              => :N,
            :route_id             => :S,
            :slug_uuid            => :S,

--- a/lib/relish/s3_helper.rb
+++ b/lib/relish/s3_helper.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/aws"
 
 class Relish
   class S3Helper

--- a/relishable.gemspec
+++ b/relishable.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
-  s.add_dependency "fog",           "~> 1.23.0"
+  s.add_dependency "fog-aws",       "~> 0.8.0"
   s.add_dependency "legacy-fernet", "~> 1.6.3"
+  s.add_dependency "net-ssh",       "~> 3.0.2"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rspec",   "~> 3.1.0"
   s.add_development_dependency "test-unit"


### PR DESCRIPTION
This introduces the concept of draft releases. A drafted release can be used when specifying it's version explicitely in `Relish.read`.
It won't be picked when using `Relish.current` though.

By default, releases without the `draft` option aren't drafted.