### PR TITLE
Upgrade fernet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     relishable (0.40)
-      fernet
+      fernet (~> 2.3)
       fog-aws (~> 0.8.0)
       legacy-fernet (~> 1.6.3)
       net-ssh (~> 3.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    relishable (0.40)
+    relishable (0.41)
       fernet (~> 2.3)
       fog-aws (~> 0.8.0)
       legacy-fernet (~> 1.6.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     relishable (0.40)
+      fernet
       fog-aws (~> 0.8.0)
       legacy-fernet (~> 1.6.3)
       net-ssh (~> 3.0.2)
@@ -11,10 +12,14 @@ GEM
   specs:
     addressable (2.3.8)
     builder (3.2.3)
+    byebug (10.0.0)
+    coderay (1.1.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     excon (0.62.0)
+    fernet (2.3)
+      valcro (~> 0.1)
     fog-aws (0.8.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
@@ -34,12 +39,19 @@ GEM
     ipaddress (0.8.3)
     legacy-fernet (1.6.4)
       multi_json (~> 1.0)
+    method_source (0.9.1)
     mini_portile2 (2.3.0)
     multi_json (1.13.1)
     net-ssh (3.0.2)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     power_assert (0.2.2)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rake (10.4.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -56,6 +68,7 @@ GEM
     safe_yaml (1.0.4)
     test-unit (3.0.8)
       power_assert
+    valcro (0.1.1)
     webmock (1.19.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -64,6 +77,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry-byebug
   rake (> 0)
   relishable!
   rspec (~> 3.1.0)
@@ -71,4 +85,4 @@ DEPENDENCIES
   webmock (~> 1.19.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/lib/relish/encryption_helper.rb
+++ b/lib/relish/encryption_helper.rb
@@ -19,6 +19,12 @@ class Relish
       current_encrypt(value)
     end
 
+    def legacy_encrypt(key, value)
+      Fernet::Legacy.generate(hmac_secrets.first) do |gen|
+        gen.data = { key => value }
+      end
+    end
+
     def decrypt(key = 'env', token)
       plain = nil
       hmac_secrets.each do |secret|
@@ -39,12 +45,6 @@ class Relish
 
     def current_encrypt(value)
       Fernet.generate(hmac_secrets.first[0, 32], value)
-    end
-
-    def legacy_encrypt(key, value)
-      Fernet::Legacy.generate(hmac_secrets.first) do |gen|
-        gen.data = { key => value }
-      end
     end
 
     def legacy?(token)

--- a/lib/relish/encryption_helper.rb
+++ b/lib/relish/encryption_helper.rb
@@ -37,13 +37,6 @@ class Relish
       plain
     end
 
-    def upgrade(key, token)
-      if verifier = verifier(hmac_secrets.first, token)
-        return encrypt(key, verifier.data[key]) if verifier.valid?
-      end
-      raise RelishDecryptionFailed
-    end
-
     def inspect
       "#<Relish::EncryptionHelper>"
     end

--- a/lib/relish/encryption_helper.rb
+++ b/lib/relish/encryption_helper.rb
@@ -1,5 +1,6 @@
 require "relish/release"
 require "fernet/legacy"
+require "fernet"
 require "openssl"
 
 class RelishDecryptionFailed < RuntimeError; end
@@ -13,18 +14,27 @@ class Relish
     end
 
     def encrypt(key, value)
+      current_encrypt(key, value)
+    end
+
+    def current_encrypt(_key, value)
+      Fernet.generate(hmac_secrets.first[0, 32], value)
+    end
+
+    def legacy_encrypt(key, value)
       Fernet::Legacy.generate(hmac_secrets.first) do |gen|
-        gen.data = {key => value}
+        gen.data = { key => value }
       end
     end
 
     def decrypt(key, token)
+      plain = nil
       hmac_secrets.each do |secret|
-        if verifier = verifier(secret, token)
-          return verifier.data[key] if verifier.valid?
-        end
+        plain = decrypt_with_secret(secret, token, key)
+        break if plain
       end
-      raise RelishDecryptionFailed
+      raise RelishDecryptionFailed unless plain
+      plain
     end
 
     def upgrade(key, token)
@@ -40,6 +50,10 @@ class Relish
 
     alias to_s inspect
 
+    def legacy?(token)
+      !!(token =~ /.+?\|.+?\|.+?/)
+    end
+
     protected
 
     def hmac_secrets
@@ -48,15 +62,23 @@ class Relish
       end
     end
 
-    def verifier(secret, token)
-      Fernet::Legacy.verifier(secret, token).tap do |verifier|
-        verifier.enforce_ttl = false
-        verifier.verify_token(token)
+    def decrypt_with_secret(secret, token, key)
+      legacy = legacy?(token)
+      verifier = if legacy
+        Fernet::Legacy.verifier(secret, token)
+      else
+        Fernet.verifier(secret[0, 32], token)
       end
+
+      verifier.enforce_ttl = false
+      verifier.verify_token(token) if legacy
+      return nil unless verifier.valid?
+
+      legacy ? verifier.data[key] : verifier.message
     rescue OpenSSL::Cipher::CipherError
-    # Certain combinations of keys and encrypted data cause decryption with an
-    # incorrect key to succeed (no CipherError) but produce garbage data which
-    # cannot be decoded into JSON, and thus fail with a ParseError instead.
+      # Certain combinations of keys and encrypted data cause decryption with an
+      # incorrect key to succeed (no CipherError) but produce garbage data which
+      # cannot be decoded into JSON, and thus fail with a ParseError instead.
     rescue MultiJson::ParseError
     end
   end

--- a/lib/relish/encryption_helper.rb
+++ b/lib/relish/encryption_helper.rb
@@ -13,11 +13,11 @@ class Relish
       @secrets = secrets
     end
 
-    def encrypt(key, value)
-      current_encrypt(key, value)
+    def encrypt(_key = 'env', value)
+      current_encrypt(value)
     end
 
-    def current_encrypt(_key, value)
+    def current_encrypt(value)
       Fernet.generate(hmac_secrets.first[0, 32], value)
     end
 
@@ -27,7 +27,7 @@ class Relish
       end
     end
 
-    def decrypt(key, token)
+    def decrypt(key = 'env', token)
       plain = nil
       hmac_secrets.each do |secret|
         plain = decrypt_with_secret(secret, token, key)

--- a/lib/relish/version.rb
+++ b/lib/relish/version.rb
@@ -1,5 +1,3 @@
 class Relish
-  VERSION = "0.40"
+  VERSION = "0.41"
 end
-
-  

--- a/relishable.gemspec
+++ b/relishable.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency "fog-aws",       "~> 0.8.0"
   s.add_dependency "legacy-fernet", "~> 1.6.3"
-  s.add_dependency "fernet"
+  s.add_dependency "fernet",        "~> 2.3"
   s.add_dependency "net-ssh",       "~> 3.0.2"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rspec",   "~> 3.1.0"

--- a/relishable.gemspec
+++ b/relishable.gemspec
@@ -14,9 +14,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency "fog-aws",       "~> 0.8.0"
   s.add_dependency "legacy-fernet", "~> 1.6.3"
+  s.add_dependency "fernet"
   s.add_dependency "net-ssh",       "~> 3.0.2"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rspec",   "~> 3.1.0"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "webmock", "~> 1.19.0"
+  s.add_development_dependency "pry-byebug"
 end

--- a/spec/relish/encryption_helper_spec.rb
+++ b/spec/relish/encryption_helper_spec.rb
@@ -26,7 +26,6 @@ describe Relish::EncryptionHelper do
       expect(Fernet).to receive(:verifier).and_raise(MultiJson::ParseError)
       assert_equal data, decrypt_helper.decrypt(key, token)
     end
-
   end
 
   it 'assumes the key is env' do

--- a/spec/relish/encryption_helper_spec.rb
+++ b/spec/relish/encryption_helper_spec.rb
@@ -27,10 +27,14 @@ describe Relish::EncryptionHelper do
       assert_equal data, decrypt_helper.decrypt(key, token)
     end
 
-    it 'assumes the key is env' do
-      token = encrypt_helper.encrypt(data)
-      assert_equal data, encrypt_helper.decrypt(token)
-    end
+  end
+
+  it 'assumes the key is env' do
+    token = encrypt_helper.encrypt(data)
+    assert_equal data, encrypt_helper.decrypt('env', token)
+
+    token = encrypt_helper.encrypt('env', data)
+    assert_equal data, encrypt_helper.decrypt(token)
   end
 
   context "upgrading" do
@@ -40,15 +44,13 @@ describe Relish::EncryptionHelper do
     end
 
     it "reads data encrypted with non-legacy fernet" do
-      token = encrypt_helper.current_encrypt('foo', 'bar')
-      assert_equal 'bar', encrypt_helper.decrypt('foo', token)
+      token = encrypt_helper.current_encrypt('bar')
+      assert_equal 'bar', encrypt_helper.decrypt(token)
     end
 
     it "writes data encrypted with non-legacy fernet" do
-      token = encrypt_helper.encrypt('foo', 'bar')
+      token = encrypt_helper.encrypt('bar')
       assert_equal false, encrypt_helper.legacy?(token)
     end
-
-    it "includes a key name as cipher meta data"
   end
 end

--- a/spec/relish_encryption_helper_spec.rb
+++ b/spec/relish_encryption_helper_spec.rb
@@ -26,6 +26,11 @@ describe Relish::EncryptionHelper do
       expect(Fernet).to receive(:verifier).and_raise(MultiJson::ParseError)
       assert_equal data, decrypt_helper.decrypt(key, token)
     end
+
+    it 'assumes the key is env' do
+      token = encrypt_helper.encrypt(data)
+      assert_equal data, encrypt_helper.decrypt(token)
+    end
   end
 
   context "upgrading" do

--- a/spec/relish_encryption_helper_spec.rb
+++ b/spec/relish_encryption_helper_spec.rb
@@ -5,6 +5,7 @@ describe Relish::EncryptionHelper do
   let(:bad_secret)  { 'b' * 32    }
   let(:key)         { 'my-key'    }
   let(:data)        { 'test-data' }
+  let(:encrypt_helper) { Relish::EncryptionHelper.new('static_secret', [good_secret]) }
 
   describe '#decrypt' do
     it 'raises RelishDecryptionFailed on incorrect decryption secret' do
@@ -18,16 +19,31 @@ describe Relish::EncryptionHelper do
     end
 
     it 'ignores keys that raise JSON errors' do
-      allow(Fernet::Legacy).to receive(:verifier).and_call_original
-      encrypt_helper = Relish::EncryptionHelper.new('static_secret', [good_secret])
+      allow(Fernet).to receive(:verifier).and_call_original
       token = encrypt_helper.encrypt(key, data)
-
       decrypt_helper = Relish::EncryptionHelper.new('static_secret', [bad_secret, good_secret])
-      bad_hmac = OpenSSL::HMAC.hexdigest('sha256', 'static_secret', bad_secret)
-      expect(Fernet::Legacy).to \
-        receive(:verifier).with(bad_hmac, token).and_raise(MultiJson::ParseError)
 
+      expect(Fernet).to receive(:verifier).and_raise(MultiJson::ParseError)
       assert_equal data, decrypt_helper.decrypt(key, token)
     end
+  end
+
+  context "upgrading" do
+    it "reads data encrypted with legacy fernet" do
+      legacy_token = encrypt_helper.legacy_encrypt('foo', 'bar')
+      assert_equal 'bar', encrypt_helper.decrypt('foo', legacy_token)
+    end
+
+    it "reads data encrypted with non-legacy fernet" do
+      token = encrypt_helper.current_encrypt('foo', 'bar')
+      assert_equal 'bar', encrypt_helper.decrypt('foo', token)
+    end
+
+    it "writes data encrypted with non-legacy fernet" do
+      token = encrypt_helper.encrypt('foo', 'bar')
+      assert_equal false, encrypt_helper.legacy?(token)
+    end
+
+    it "includes a key name as cipher meta data"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "rubygems"
 require "bundler"
 
+require "date" # work around issue with safe_yaml
 Bundler.require(:default, :development)
 
 require "webmock/rspec"


### PR DESCRIPTION
This changes relish to always encrypt data using the current version of fernet, but to decrypt data using either legacy or current methods depending on the form of the ciphertext. Once all data has been re-encrypted legacy fernet would no longer be required.