### PR TITLE
update master references to main

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,10 +22,10 @@ task :release do
   sh "ruby", "-i", "-pe", "$_.gsub!(/VERSION = .*/, %{VERSION = \"#{new_version}\"})", "lib/relish/version.rb"
   sh "bundle install"
   sh "git commit -a -m 'v#{new_version}'"
-  sh "git tag v#{new_version} && git push origin master --tags"
+  sh "git tag v#{new_version} && git push origin main --tags"
   sh "gem build relishable.gemspec"
   sh "gem push relishable-#{new_version}.gem"
-  sh "git push origin master --tags"
+  sh "git push origin main --tags"
   sh "rm relishable-#{new_version}.gem"
 end
 


### PR DESCRIPTION
Context
We are renaming the default git branch to main and as such we are updating docs to reflect this change

Timing
not urgent

Risk
low risk

Rollback Procedure
revert PR

SOC2 Compliance Reference

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FXEBAYA5/view