### PR TITLE
Waits a week before updating a dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,20 @@ updates:
     insecure-external-code-execution: allow
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      time: "12:00"
+      day: "wednesday"
+      timezone: "America/Los_Angeles"
+    cooldown:
+      default-days: 7
+    labels: []
+    groups:
+      minor-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # ignore all major version updates
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Context
Supply chain attacks are happening more frequently than ever. Our Dependabot update strategy is very aggressive, as soon as a new version is available it's picked up. This leaves us at risk of updating to a compromised version of a dependency.

With the current setup, we put the burden on the PR reviewer to determine if the change is safe or not.

I propose setting a cooldown period to regular updates, Dependabot will wait until the new version is, at least, 7 days old before submitting a PR with the update. Usually, this kind of attacks, last less than a week and the compromised versions are removed quickly.

This change doesn't affect security patches, those are handled by a different flow and a CVE must exist so the chances of an attack via that vector are lower.

I'm also adding some rules that were missing, like only doing minor versions and weekly schedule.

## SOC2 Compliance Reference
https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-