### PR TITLE
Remove deprecated calls and drop support for EOLd Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0' ]
+        ruby: [ '3.3', '3.4', '4.0' ]
     runs-on: ubuntu-22.04
 
     name: Setup env & run tests

--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) ([except for prereleases unfortunately](https://makandracards.com/makandra/498416-pre-releasing-a-ruby-gem/read)).
+
+## Unreleased
+
+## [2.0.0] 2026-04-21
+- Drops support for Ruby vesions lower than 3.3

--- a/lib/relish/version.rb
+++ b/lib/relish/version.rb
@@ -1,3 +1,3 @@
 class Relish
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/relishable.gemspec
+++ b/relishable.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary = "releases"
   s.authors = ["Mark Fine", "Blake Gentry", "Pedro Belo", "Joshua Tobin"]
   s.homepage = "http://github.com/heroku/relish"
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.3.0"
 
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]

--- a/spec/relish_spec.rb
+++ b/spec/relish_spec.rb
@@ -11,7 +11,7 @@ describe Relish do
     it "makes a POST to the Dynamo API" do
       @relish.copy("1234", "1", { name: "foobar" })
       assert_requested(:post, @dynamo_url) do |req|
-        params = MultiJson.decode(req.body)
+        params = MultiJson.load(req.body)
         item   = params["Item"]
         params["TableName"] == "table" &&
           item["id"]      == { "S" => "1234" } &&
@@ -24,7 +24,7 @@ describe Relish do
     it "creates a draft release" do
       @relish.copy("1234", "1", { name: "foobar", draft: true })
       assert_requested(:post, @dynamo_url) do |req|
-        params = MultiJson.decode(req.body)
+        params = MultiJson.load(req.body)
         params["Item"]["draft"] == { "BOOL" => 'true' }
       end
     end
@@ -62,7 +62,7 @@ describe Relish do
       @relish.current("1234")
 
       assert_requested(:post, @dynamo_url) do |req|
-        params = MultiJson.decode(req.body)
+        params = MultiJson.load(req.body)
         params['KeyConditionExpression'] == 'id = :id AND version > :version' &&
           params['FilterExpression'] == 'draft <> :isDraft' &&
           params['ExpressionAttributeValues'] == {
@@ -78,7 +78,7 @@ describe Relish do
     it "makes a POST to the Dynamo API" do
       @relish.create("1234", { name: "foobar" })
       assert_requested(:post, @dynamo_url) do |req|
-        params = MultiJson.decode(req.body)
+        params = MultiJson.load(req.body)
         params['KeyConditionExpression'] == 'id = :id AND version > :version' &&
           params['ExpressionAttributeValues'] == {
             ':id' => {'S' => '1234'},


### PR DESCRIPTION
Ruby 3.1 and 3.2 are no longer supported https://www.ruby-lang.org/en/downloads/branches/

https://github.com/heroku/relish/pull/92#discussion_r3133008147