### PR TITLE
Uses approved runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,16 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '3.3', '3.4', '4.0' ]
-    runs-on: ubuntu-22.04
+    runs-on: pub-hk-ubuntu-24.04-medium
 
     name: Setup env & run tests
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: sfdc-hk-ubuntu-latest
+    runs-on: pub-hk-ubuntu-24.04-medium
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0


### PR DESCRIPTION
One of the workflows was using the regular ubuntu runner whilst the other was using one meant for private repos. I'm updating it to only use approved runners for public repos.

https://github.com/heroku/relish/actions/runs/24906931583